### PR TITLE
Adds rust-like primitive types names

### DIFF
--- a/macros.h
+++ b/macros.h
@@ -26,6 +26,15 @@
 #define EQUALS    ==
 #define IS        =
 
+/* TYPES */
+
+#define INT16  short
+#define UINT16 unsigned short
+#define INT32  int
+#define UINT32 unsigned int
+#define INT64  long long
+#define UINT64 unsigned long long
+
 /* Loops */
 
 #define FOREVER       for(;;)


### PR DESCRIPTION
I see this naming scheme as more expressive and easy to understand especially to the newcomers. I know some gonna say that the size may differ in some platforms but let's be honest are realistic here, in 99% of the platform we target nothing changes in most of the types.
I've referred to INT64 as long long instead of long to ensure the 64bit-size in case of targeting ARM architecture.